### PR TITLE
Update the thread pool library.

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -7,7 +7,7 @@ range-v3/0.11.0
 sdl/2.0.20
 glbinding/3.1.0
 glm/0.9.9.8
-bshoshany-thread-pool/3.4.0
+bshoshany-thread-pool/4.0.1
 cpprestsdk/2.10.15
 cpr/1.10.4
 nlohmann_json/3.11.2

--- a/include/miquella/core/rendererThreads.h
+++ b/include/miquella/core/rendererThreads.h
@@ -20,13 +20,17 @@ class RendererThreads : public Renderer
 public:
     RendererThreads() : Renderer(){}
     RendererThreads(std::shared_ptr<Scene> scene, std::shared_ptr<Camera> camera, uint32_t poolSize = 1) :
-        Renderer(scene, camera), m_pool(poolSize){}
+        Renderer(scene, camera), m_pool(poolSize), m_nbThreads(poolSize), m_nbBlocks(2*poolSize){}
 
     virtual ~RendererThreads(){  }
 
-    void setNbThreads(int nbThreads)
+    void setNbThreads(uint32_t nbThreads)
     {
         m_nbThreads = nbThreads;
+        m_pool.reset(m_nbThreads);
+
+        // Testing heuristic of double the number of block. 
+        m_nbBlocks = 2*nbThreads;
     }
 
     virtual void updateImageFromCamera() override
@@ -43,7 +47,9 @@ public:
 public:
     BS::thread_pool m_pool;
     size_t m_totalExecutionAccumulated = 0;
-    int m_nbThreads = 1;
+    uint32_t m_nbThreads = 1;
+    uint32_t m_nbBlocks = 1;
+
 //    std::vector<int> m_heightIndexes;   // Array used to store a counter from m_height-1 to 0
 };
 

--- a/src/services/server/server.cpp
+++ b/src/services/server/server.cpp
@@ -59,7 +59,7 @@ void runRenderer(
     //renderer.setScene(scene);
     //renderer.setCamera(camera);
     renderer.setBackground(background);
-    renderer.setNbThreads(nbThreads);
+    //renderer.setNbThreads(nbThreads);
 
     for(size_t i = 1; i <= maxSamples; ++i)
     {
@@ -177,6 +177,8 @@ int main(int argc, char** argv)
     }
     else
         spdlog::info("Unrecognized log level. Using info by default.");
+
+    spdlog::info("Starting the server with {} threads.", nbThreads);
 
     srand(static_cast<unsigned int>(time(nullptr)));
 

--- a/src/standalone/main.cpp
+++ b/src/standalone/main.cpp
@@ -415,7 +415,7 @@ int main(int argc, char** argv)
 {
 
     size_t sceneID = 3;
-    int nbThreads = 1;
+    uint32_t nbThreads = 1;
 
     std::vector<void (*)(miquella::core::Renderer&)> scenes;
     scenes.push_back(generateScene1);


### PR DESCRIPTION
Switch the thread pool library to 4.0.1. Update syntax accordingly. Minor update of the code to decorelate the number of blocks from the number of threads. Will be useful for benchmarking in another issue.

Fix #12 