### PR TITLE
Add benchmarking executable and setup a couple of tests. 

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -11,6 +11,7 @@ bshoshany-thread-pool/4.0.1
 cpprestsdk/2.10.15
 cpr/1.10.4
 nlohmann_json/3.11.2
+benchmark/1.8.3
 
 [options]
 sdl:jack=False

--- a/include/miquella/core/rendererThreads.h
+++ b/include/miquella/core/rendererThreads.h
@@ -33,6 +33,11 @@ public:
         m_nbBlocks = 2*nbThreads;
     }
 
+    void setNbBlocks(uint32_t nbBlocks)
+    {
+        m_nbBlocks = nbBlocks;
+    }
+
     virtual void updateImageFromCamera() override
     {
         Renderer::updateImageFromCamera();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(lib)
 add_subdirectory(services)
 add_subdirectory(standalone)
+add_subdirectory(benchmark)

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(MainBenchmark mainBenchmark.cpp)
+
+target_link_libraries(MainBenchmark
+                                MQ_project_libraries
+                                MQ_project_options
+                                MQ_project_warnings
+                                ${PROJECT_NAME}::imgui
+                                MiquellaLib
+                                CONAN_PKG::benchmark
+                     )
+install(TARGETS
+            MainBenchmark
+        DESTINATION
+            ${MQ_BIN_DIR}
+        )

--- a/src/benchmark/mainBenchmark.cpp
+++ b/src/benchmark/mainBenchmark.cpp
@@ -1,0 +1,54 @@
+#include <benchmark/benchmark.h>
+
+#include <miquella/core/rendererThreads.h>
+#include <miquella/core/sceneFactory.h>
+
+
+static void runBenchmarkScene(miquella::core::SceneID sceneID, size_t nSamples, uint32_t nbThreads, uint32_t nbBlocks)
+{
+    miquella::core::SceneFactory sceneFactory;
+        auto [ scene, camera, background ] = sceneFactory.createScene(sceneID);
+
+        miquella::core::RendererThreads renderer(scene, camera, nbThreads);
+        renderer.setNbBlocks(nbBlocks);
+        renderer.setBackground(background);
+
+        
+        for(size_t i = 1; i <= nSamples; ++i)
+        {
+            // Compute the image
+            renderer.render();
+        }
+        std::cout<<"Completed "<<nSamples<<" samples for "<<nbThreads<<" threads and "<<nbBlocks<<" blocks."<<std::endl;
+}
+
+static void BM_ThreeBall(benchmark::State& state)
+{
+    for(auto _ : state)
+    {
+        auto sceneID = miquella::core::SceneID::SCENE_THREE_BALLS;
+        size_t nSamples = 500;
+        uint32_t nbThreads = static_cast<uint32_t>(state.range(0));
+        uint32_t nbBlocks = static_cast<uint32_t>(state.range(1));
+
+        runBenchmarkScene(sceneID, nSamples, nbThreads, nbBlocks);
+    }
+}
+
+static void BM_OneWeekend(benchmark::State& state)
+{
+    for(auto _ : state)
+    {
+        auto sceneID = miquella::core::SceneID::SCENE_ONE_WEEKEND;
+        size_t nSamples = 50;
+        uint32_t nbThreads = static_cast<uint32_t>(state.range(0));
+        uint32_t nbBlocks = static_cast<uint32_t>(state.range(1));
+
+        runBenchmarkScene(sceneID, nSamples, nbThreads, nbBlocks);
+    }
+}
+
+BENCHMARK(BM_ThreeBall)->Args({6,6})->Args({6, 12})->MeasureProcessCPUTime();
+BENCHMARK(BM_OneWeekend)->Args({6,6})->Args({6, 12});
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Add benchmarks to the build. Update the threaded renderer to decouple the number of blocks from the number of threads.

Fix #14 
